### PR TITLE
Fix broken iteration of items in Opentype.js glyphs object

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,17 +20,19 @@ opentype.load(opts.f, function(err, font) {
 		return;
 	}
 
-	if (!font.glyphs || font.glyphs.length === 0) {
+	var glyphs = font.glyphs.glyphs;
+	if (!glyphs || glyphs.length === 0) {
 		console.log('no glyphs found in this font');
 		return;
 	}
 
 	var table = '';
-	font.glyphs.forEach(function(glyph) {
+	Object.keys(glyphs).forEach(function(key) {
+		var glyph = glyphs[key];
 		if (!glyph.unicode) {
 			return;
 		}
-
+		
 		table += String.fromCharCode(glyph.unicode);
 	});
 

--- a/index.js
+++ b/index.js
@@ -27,14 +27,12 @@ opentype.load(opts.f, function(err, font) {
 	}
 
 	var table = '';
-	Object.keys(glyphs).forEach(function(key) {
-		var glyph = glyphs[key];
-		if (!glyph.unicode) {
-			return;
+	for(glyphIndex in glyphs) {
+		var glyph = glyphs[glyphIndex];
+		if (glyph.unicode) {
+			table += String.fromCharCode(glyph.unicode);
 		}
-		
-		table += String.fromCharCode(glyph.unicode);
-	});
+	}
 
 	console.log(table);
 });


### PR DESCRIPTION
Fixing issue(#1). @strarsis mentioned that it's probably because opentype.js changed its API. This seems to do the trick.
